### PR TITLE
fix: register page responds with 404

### DIFF
--- a/docs/bugs/register-button-404.md
+++ b/docs/bugs/register-button-404.md
@@ -1,0 +1,26 @@
+---
+name: 🐛 Bug Report
+about: Report a bug or issue in Podfilter
+title: "fix: register page link returns 404"
+labels: ["bug"]
+assignees: ""
+---
+
+## 🐛 Bug Description
+Clicking the **Register** button on the landing page navigates to `/register` but the request returns a `404 Not Found`. The template route exists in `podfilter/routes/web.py`, but it is not wired into the Litestar application, so the page never resolves.
+
+## 🔄 Steps to Reproduce
+1. Start the dev server with `python run.py`.
+2. Open `http://localhost:8000/` in a browser.
+3. Click the **Register** button on the hero section.
+
+## ✅ Expected Behavior
+The `/register` route should render the registration form so that a new user can create an account.
+
+## ❌ Actual Behavior
+The browser receives a `404 Not Found` response and the registration form never renders. The Litestar logs show the request falling through because the handler is not registered with the app.
+
+## 🖥️ Environment
+- **Frontend**: Local dev UI served from `http://localhost:8000/`
+- **Backend**: `main` (current HEAD) via `python run.py`
+- **Browser**: Chrome 126 on macOS 14.5

--- a/docs/prs/fix-register-route.md
+++ b/docs/prs/fix-register-route.md
@@ -1,0 +1,12 @@
+# fix: register page responds with 404
+
+Fixes #3.
+
+## Summary
+- wire the Litestar app to use the routers defined in `podfilter/routes` instead of ad-hoc handlers in `podfilter/app.py`.
+- configure the Jinja template engine and static files so template based pages render correctly.
+- update the base template to use static asset paths that align with Litestar's static router, fixing 500s from missing globals.
+
+## Testing
+- `python -m compileall podfilter/app.py`
+- Manual QA: `python run.py`, navigate to `/`, `/register`, and `/login` to confirm pages render.

--- a/podfilter/app.py
+++ b/podfilter/app.py
@@ -1,20 +1,15 @@
 """Main PodFilter application."""
 
 from pathlib import Path
-from typing import Dict, Any
 
-from litestar import Litestar, Request, get
+from litestar import Litestar
 from litestar.config.cors import CORSConfig
-from litestar.exceptions import HTTPException
-from litestar.response import Template, Response
 from litestar.static_files import create_static_files_router
 from litestar.template.config import TemplateConfig
-from sqlalchemy import create_engine
-from sqlalchemy.ext.asyncio import create_async_engine
+from litestar.contrib.jinja import JinjaTemplateEngine
 
-from .database import Base, DATABASE_URL, engine
-from .routes import auth, feeds
-from .routes import auth, feeds
+from .database import Base, engine
+from .routes import auth, export, feeds, web
 
 
 async def create_tables() -> None:
@@ -23,331 +18,49 @@ async def create_tables() -> None:
     await conn.run_sync(Base.metadata.create_all)
 
 
-@get("/")
-async def homepage(request: Request) -> Response:
-  """Simple homepage for testing."""
-  html_content = """
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>PodFilter</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    </head>
-    <body>
-        <div class="container mt-5">
-            <h1>Welcome to PodFilter</h1>
-            <p>Podcast feed filtering service</p>
-            <a href="/register" class="btn btn-primary">Register</a>
-            <a href="/login" class="btn btn-outline-primary">Login</a>
-        </div>
-    </body>
-    </html>
-    """
-  return Response(content=html_content, media_type="text/html")
-
-
-@get("/login")
-async def login_page(request: Request) -> Response:
-  """Login page."""
-  html_content = """
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Login - PodFilter</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    </head>
-    <body>
-        <div class="container mt-5">
-            <div class="row justify-content-center">
-                <div class="col-md-6">
-                    <div class="card">
-                        <div class="card-header">
-                            <h4>Login to PodFilter</h4>
-                        </div>
-                        <div class="card-body">
-                            <form id="loginForm">
-                                <div class="mb-3">
-                                    <label for="username" class="form-label">Username</label>
-                                    <input type="text" class="form-control" id="username" name="username" required>
-                                </div>
-                                <div class="mb-3">
-                                    <label for="password" class="form-label">Password</label>
-                                    <input type="password" class="form-control" id="password" name="password" required>
-                                </div>
-                                <button type="submit" class="btn btn-primary w-100">Login</button>
-                            </form>
-                            <div class="text-center mt-3">
-                                <p>Don't have an account? <a href="/register">Register here</a></p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <script>
-        document.getElementById('loginForm').addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const formData = new FormData(e.target);
-            const data = Object.fromEntries(formData);
-            
-            try {
-                const response = await fetch('/api/login', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify(data)
-                });
-                
-                if (response.ok) {
-                    const result = await response.json();
-                    localStorage.setItem('access_token', result.access_token);
-                    window.location.href = '/dashboard';
-                } else {
-                    const error = await response.json();
-                    alert(error.detail || 'Login failed');
-                }
-            } catch (error) {
-                alert('Login failed: ' + error.message);
-            }
-        });
-        </script>
-    </body>
-    </html>
-    """
-  return Response(content=html_content, media_type="text/html")
-
-
-@get("/dashboard")
-async def dashboard(request: Request) -> Response:
-  """Dashboard page for authenticated users."""
-  html_content = """
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Dashboard - PodFilter</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    </head>
-    <body>
-        <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
-            <div class="container">
-                <a class="navbar-brand" href="/">PodFilter</a>
-                <div class="navbar-nav ms-auto">
-                    <a class="nav-link" href="#" onclick="logout()">Logout</a>
-                </div>
-            </div>
-        </nav>
-        <div class="container mt-4">
-            <h1>Welcome to your Dashboard!</h1>
-            <p class="lead">Manage your podcast feeds and filtering rules.</p>
-            
-            <div class="row mt-4">
-                <div class="col-md-6">
-                    <div class="card">
-                        <div class="card-header">
-                            <h5>Quick Actions</h5>
-                        </div>
-                        <div class="card-body">
-                            <button class="btn btn-primary" onclick="showAddFeedModal()">Add RSS Feed</button>
-                            <button class="btn btn-outline-secondary ms-2" onclick="showImportOPML()">Import OPML</button>
-                        </div>
-                    </div>
-                </div>
-                <div class="col-md-6">
-                    <div class="card">
-                        <div class="card-header">
-                            <h5>Your Activity</h5>
-                        </div>
-                        <div class="card-body">
-                            <p>No feeds added yet. <a href="#" onclick="showAddFeedModal()">Add your first feed!</a></p>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        
-        <script>
-        function logout() {
-            localStorage.removeItem('access_token');
-            window.location.href = '/';
-        }
-        
-        async function showAddFeedModal() {
-            const url = prompt('Enter RSS feed URL:');
-            if (url) {
-                try {
-                    const response = await fetch('/api/feeds', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/json',
-                            'Authorization': 'Bearer ' + localStorage.getItem('access_token')
-                        },
-                        body: JSON.stringify({url: url})
-                    });
-                    
-                    if (response.ok) {
-                        alert('Feed added successfully!');
-                        location.reload();
-                    } else {
-                        const error = await response.json();
-                        alert('Failed to add feed: ' + (error.detail || 'Unknown error'));
-                    }
-                } catch (error) {
-                    alert('Failed to add feed: ' + error.message);
-                }
-            }
-        }
-        
-        function showImportOPML() {
-            alert('OPML import functionality coming soon!');
-        }
-        
-        // Load feeds on page load
-        async function loadFeeds() {
-            try {
-                const response = await fetch('/api/feeds', {
-                    headers: {
-                        'Authorization': 'Bearer ' + localStorage.getItem('access_token')
-                    }
-                });
-                
-                if (response.ok) {
-                    const feeds = await response.json();
-                    const activityDiv = document.querySelector('.card-body p');
-                    if (feeds.length > 0) {
-                        activityDiv.innerHTML = `You have ${feeds.length} feed(s). <a href="#" onclick="listFeeds()">View all feeds</a>`;
-                    }
-                }
-            } catch (error) {
-                console.error('Failed to load feeds:', error);
-            }
-        }
-        
-        async function listFeeds() {
-            try {
-                const response = await fetch('/api/feeds', {
-                    headers: {
-                        'Authorization': 'Bearer ' + localStorage.getItem('access_token')
-                    }
-                });
-                
-                if (response.ok) {
-                    const feeds = await response.json();
-                    let feedList = '<h5>Your Feeds:</h5><ul>';
-                    feeds.forEach(feed => {
-                        feedList += `<li><strong>${feed.title}</strong><br><small>${feed.original_url}</small></li>`;
-                    });
-                    feedList += '</ul>';
-                    
-                    const activityCard = document.querySelector('.card-body');
-                    activityCard.innerHTML = feedList;
-                }
-            } catch (error) {
-                alert('Failed to load feeds: ' + error.message);
-            }
-        }
-        
-        // Load feeds when page loads
-        document.addEventListener('DOMContentLoaded', loadFeeds);
-        </script>
-    </body>
-    </html>
-    """
-  return Response(content=html_content, media_type="text/html")
-
-
-async def register_page(request: Request) -> Response:
-  """Registration page."""
-  html_content = """
-    <!DOCTYPE html>
-    <html>
-    <head>
-        <title>Register - PodFilter</title>
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    </head>
-    <body>
-        <div class="container mt-5">
-            <div class="row justify-content-center">
-                <div class="col-md-6">
-                    <div class="card">
-                        <div class="card-header">
-                            <h4>Register for PodFilter</h4>
-                        </div>
-                        <div class="card-body">
-                            <form id="registerForm">
-                                <div class="mb-3">
-                                    <label for="username" class="form-label">Username</label>
-                                    <input type="text" class="form-control" id="username" name="username" required>
-                                </div>
-                                <div class="mb-3">
-                                    <label for="email" class="form-label">Email</label>
-                                    <input type="email" class="form-control" id="email" name="email" required>
-                                </div>
-                                <div class="mb-3">
-                                    <label for="password" class="form-label">Password</label>
-                                    <input type="password" class="form-control" id="password" name="password" required>
-                                </div>
-                                <button type="submit" class="btn btn-primary w-100">Register</button>
-                            </form>
-                            <div class="text-center mt-3">
-                                <p>Already have an account? <a href="/login">Login here</a></p>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <script>
-        document.getElementById('registerForm').addEventListener('submit', async (e) => {
-            e.preventDefault();
-            const formData = new FormData(e.target);
-            const data = Object.fromEntries(formData);
-            
-            try {
-                const response = await fetch('/api/register', {
-                    method: 'POST',
-                    headers: {'Content-Type': 'application/json'},
-                    body: JSON.stringify(data)
-                });
-                
-                if (response.ok) {
-                    alert('Registration successful! Please login.');
-                    window.location.href = '/login';
-                } else {
-                    const error = await response.json();
-                    alert(error.detail || 'Registration failed');
-                }
-            } catch (error) {
-                alert('Registration failed: ' + error.message);
-            }
-        });
-        </script>
-    </body>
-    </html>
-    """
-  return Response(content=html_content, media_type="text/html")
-
-
-# Static files configuration
 static_files_router = create_static_files_router(path="/static", directories=[Path(__file__).parent / "static"])
 
-# CORS configuration for API access
 cors_config = CORSConfig(
-  allow_origins=["*"], allow_methods=["GET", "POST", "PUT", "DELETE"], allow_headers=["*"], allow_credentials=True
+  allow_origins=["*"],
+  allow_methods=["GET", "POST", "PUT", "DELETE"],
+  allow_headers=["*"],
+  allow_credentials=True,
 )
 
-# Create Litestar application
+route_handlers = [
+  static_files_router,
+  # Web routes
+  web.index,
+  web.login_page,
+  web.register_page,
+  web.feeds_page,
+  web.filters_page,
+  # Authentication routes
+  auth.register,
+  auth.login,
+  auth.logout,
+  # Feed management routes
+  feeds.add_feed,
+  feeds.import_opml,
+  feeds.list_feeds,
+  feeds.add_filter_rule,
+  feeds.list_filter_rules,
+  feeds.delete_filter_rule,
+  # Export routes
+  export.export_rss_feed,
+  export.export_opml,
+]
+
+template_config = TemplateConfig(
+  directory=Path(__file__).parent / "templates",
+  engine=JinjaTemplateEngine,
+)
+
 app = Litestar(
-  route_handlers=[
-    static_files_router,
-    homepage,
-    login_page,
-    dashboard,
-    # API routes
-    auth.register,
-    auth.login,
-    auth.logout,
-  ],
+  route_handlers=route_handlers,
   cors_config=cors_config,
   on_startup=[create_tables],
+  template_config=template_config,
   debug=True,
 )
 

--- a/podfilter/templates/base.html
+++ b/podfilter/templates/base.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}PodFilter{% endblock %}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/css/bootstrap.min.css" rel="stylesheet">
-    <link href="{{ url_for_static_file('css/style.css') }}" rel="stylesheet">
+    <link href="/static/css/style.css" rel="stylesheet">
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-dark bg-primary">
@@ -30,7 +30,7 @@
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.3/dist/js/bootstrap.bundle.min.js"></script>
-    <script src="{{ url_for_static_file('js/app.js') }}"></script>
+    <script src="/static/js/app.js"></script>
     {% block scripts %}{% endblock %}
 </body>
 </html>


### PR DESCRIPTION
# fix: register page responds with 404

Fixes #3.

## Summary
- wire the Litestar app to use the routers defined in `podfilter/routes` instead of ad-hoc handlers in `podfilter/app.py`.
- configure the Jinja template engine and static files so template based pages render correctly.
- update the base template to use static asset paths that align with Litestar's static router, fixing 500s from missing globals.

## Testing
- `python -m compileall podfilter/app.py`
- Manual QA: `python run.py`, navigate to `/`, `/register`, and `/login` to confirm pages render.
