### PR TITLE
feat: add robot browser acceptance suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,10 @@ logs/
 uploads/
 static/uploads/
 instance/
+
+# Acceptance test artifacts
+acceptance/results/
+log.html
+output.xml
+playwright-log.txt
+report.html

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # podfilter
 Service that imports podcast feeds, applies filters to what episode to hide from it and then exposes a new rss feed with filtered items removed
+
+## Robot Framework Acceptance Tests
+1. Install dev dependencies: `pip install -e .[dev]`.
+2. Download Playwright browsers once: `rfbrowser init`.
+3. Run the app in another terminal via `python run.py`.
+4. Execute the suite: `robot -d acceptance/results acceptance/suites`.
+   - Override the target with `BASE_URL=http://localhost:8000` if your server runs on a custom address.

--- a/acceptance/resources/browser.resource
+++ b/acceptance/resources/browser.resource
@@ -1,0 +1,27 @@
+*** Settings ***
+Library  Browser
+Library  OperatingSystem
+
+*** Variables ***
+${BASE_URL}    http://localhost:8000
+${BROWSER}    chromium
+
+*** Keywords ***
+Initialize Variables
+  ${url}=  Get Environment Variable  BASE_URL   default=http://localhost:8000
+  ${bro}=  Get Environment Variable  BROWSER   default=chromium
+  VAR   ${BASE_URL}   ${url}   scope=GLOBAL
+  VAR  ${BROWSER}   ${bro}   scope=GLOBAL
+
+Open Browser Session
+  Initialize Variables
+  New Browser  browser=${BROWSER}  headless=${TRUE}
+
+Close Browser Session
+  Close Browser
+
+Open Landing Page
+  New Page  ${BASE_URL}/
+
+Close Active Page
+  Close Page

--- a/acceptance/suites/landing_and_auth.robot
+++ b/acceptance/suites/landing_and_auth.robot
@@ -1,0 +1,21 @@
+*** Settings ***
+Resource  ../resources/browser.resource
+Suite Setup  Open Browser Session
+Suite Teardown  Close Browser Session
+Test Setup  Open Landing Page
+Test Teardown  Close Active Page
+
+*** Test Cases ***
+Landing Page Displays CTA Buttons
+  ${primary_cta}=  Get Text  css=a.btn-primary.btn-lg
+  Should Contain  ${primary_cta}  Get Started
+  ${secondary_cta}=  Get Text  css=a.btn-outline-primary.btn-lg
+  Should Contain  ${secondary_cta}  Login
+
+Register Button Opens Registration Form
+  Click  text=Get Started
+  Wait For Elements State  css=form#registerForm  state=visible  timeout=5s
+
+Login Link Navigates To Login Form
+  Click  a.btn:has-text("Login")
+  Wait For Elements State  css=form#loginForm  state=visible  timeout=5s

--- a/docs/features/robot-acceptance-tests.md
+++ b/docs/features/robot-acceptance-tests.md
@@ -1,0 +1,21 @@
+---
+name: 🚀 Feature Request
+about: Request a new feature or enhancement for Podfilter
+title: "feat: add acceptance tests with robotframework-browser"
+labels: ["enhancement"]
+assignees: ""
+---
+
+## 🎯 Feature Description
+Introduce automated end-to-end acceptance tests using the `robotframework-browser` library. These tests should cover critical user flows (registration, login, feed management) and run in CI to prevent regressions in the web UI.
+
+## ✅ Acceptance Criteria
+- [ ] Given Robot test suites are added, When `robot` is executed locally, Then scenarios for landing page, registration, and login succeed against the dev server.
+- [ ] Given the CI pipeline runs, When the acceptance suite executes headlessly, Then the pipeline reports pass/fail status and fails on regression.
+
+## 🔧 Technical Requirements
+- [x] Frontend changes needed
+- [x] Backend changes needed
+- [ ] Database changes needed
+- [x] Infrastructure changes needed
+- [x] Tooling changes needed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,8 @@ dev = [
     "black>=23.0.0",
     "ruff>=0.1.0",
     "mypy>=1.5.0",
+    "robotframework>=6.1",
+    "robotframework-browser>=18.0.0",
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- add robotframework + robotframework-browser to dev extras
- scaffold acceptance resources and initial landing/auth suite
- document setup/run steps and ignore Robot result output

## Testing
- robot -d acceptance/results acceptance/suites

Fixes #7.