### PR TITLE
feat: clean dashboard filter references

### DIFF
--- a/podfilter/routes/web.py
+++ b/podfilter/routes/web.py
@@ -47,19 +47,15 @@ async def index(
   user = await get_current_user_optional(request, session)
 
   if user:
-    # Get user's feeds and filter rules for dashboard
+    # Get user's feeds for dashboard
     feeds_result = await session.execute(select(Feed).where(Feed.user_id == user.id, Feed.is_active == True))
     feeds = feeds_result.scalars().all()
-
-    rules_result = await session.execute(select(FilterRule).where(FilterRule.user_id == user.id))
-    filter_rules = rules_result.scalars().all()
 
     return Template(
       template_name="dashboard.html",
       context={
         "user": user,
         "feeds": feeds,
-        "filter_rules": filter_rules,
       },
     )
   else:

--- a/podfilter/templates/dashboard.html
+++ b/podfilter/templates/dashboard.html
@@ -6,12 +6,12 @@
 <div class="row">
     <div class="col-12">
         <h1>Welcome back, {{ user.username }}!</h1>
-        <p class="lead">Manage your podcast feeds and filtering rules.</p>
+        <p class="lead">Manage your podcast feeds.</p>
     </div>
 </div>
 
 <div class="row mt-4">
-    <div class="col-md-6">
+    <div class="col-12 col-lg-8">
         <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">Your Feeds ({{ feeds|length }})</h5>
@@ -41,37 +41,6 @@
             </div>
         </div>
     </div>
-    
-    <div class="col-md-6">
-        <div class="card">
-            <div class="card-header d-flex justify-content-between align-items-center">
-                <h5 class="mb-0">Filter Rules ({{ filter_rules|length }})</h5>
-                <a href="/filters" class="btn btn-primary btn-sm">Manage Filters</a>
-            </div>
-            <div class="card-body">
-                {% if filter_rules %}
-                    <div class="list-group list-group-flush">
-                        {% for rule in filter_rules[:5] %}
-                        <div class="list-group-item">
-                            <div class="d-flex w-100 justify-content-between">
-                                <h6 class="mb-1">{{ rule.rule_type.replace('_', ' ').title() }}</h6>
-                                <small class="text-muted">{{ rule.action }}</small>
-                            </div>
-                            <p class="mb-1">{{ rule.pattern }}</p>
-                        </div>
-                        {% endfor %}
-                        {% if filter_rules|length > 5 %}
-                        <div class="list-group-item text-center">
-                            <small class="text-muted">And {{ filter_rules|length - 5 }} more...</small>
-                        </div>
-                        {% endif %}
-                    </div>
-                {% else %}
-                    <p class="text-muted">No filter rules created yet. <a href="/filters">Create your first filter!</a></p>
-                {% endif %}
-            </div>
-        </div>
-    </div>
 </div>
 
 <div class="row mt-4">
@@ -82,16 +51,13 @@
             </div>
             <div class="card-body">
                 <div class="row">
-                    <div class="col-md-3 mb-2">
+                    <div class="col-md-4 mb-2">
                         <a href="/feeds" class="btn btn-outline-primary w-100">Add Feed</a>
                     </div>
-                    <div class="col-md-3 mb-2">
-                        <a href="/filters" class="btn btn-outline-primary w-100">Create Filter</a>
-                    </div>
-                    <div class="col-md-3 mb-2">
+                    <div class="col-md-4 mb-2">
                         <a href="/export/opml" class="btn btn-outline-success w-100">Export OPML</a>
                     </div>
-                    <div class="col-md-3 mb-2">
+                    <div class="col-md-4 mb-2">
                         <button class="btn btn-outline-info w-100" onclick="showImportModal()">Import OPML</button>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary
- drop the filter summary card from the dashboard and streamline the hero copy
- remove the "Create Filter" quick action so only feed actions remain
- stop loading filter rules in the dashboard route now that they are unused

## Testing
- not run (UI change)

Closes #16.
